### PR TITLE
Line 288.  Throws error when page submitted with no taxonomy items selected

### DIFF
--- a/acf-tax.php
+++ b/acf-tax.php
@@ -286,14 +286,16 @@ class Tax_field extends acf_Field
 	function update_value($post_id, $field, $value)
 	{
 
-		foreach($value as $term) {
-			$terms[] = intval( $term );
-		}
+		if(is_array($value))
+			foreach($value as $term) {
+				$terms[] = intval( $term );
+			}
 
 		
-		$value = wp_set_object_terms( $post_id, $terms, $field[ 'taxonomy' ], false );
+			$value = wp_set_object_terms( $post_id, $terms, $field[ 'taxonomy' ], false );
 		
-		parent::update_value( $post_id, $field, $value );
+			parent::update_value( $post_id, $field, $value );
+		}
 		
 	}
 	


### PR DESCRIPTION
When using this add-on and submitting a post without selecting any taxonomy items an error is thrown due to trying to carryout a foreach on a non-array. Line 288.

Fixing Code attached
