### PR TITLE
Update acf-tax.php

### DIFF
--- a/acf-tax.php
+++ b/acf-tax.php
@@ -366,9 +366,25 @@ class Tax_field extends acf_Field
 
 	function get_value_for_api($post_id, $field)
 	{
-		$terms = get_terms($field['taxonomy']);
+	        if( is_numeric($post_id) )
+	    	{        
+	    		// get values
+    			$terms = get_terms($field['taxonomy']);
+		}else{
+     	    		$terms=array();
+    			$stored_values = get_option( $post_id . '_' . $field['name'], null );
+            
+            		if(is_array($stored_values)){
+    	 	    		$all_terms=wp_get_object_terms($post_id,$field['taxonomy']);
+            			foreach($terms as $term) {
+        				if(in_array($term->term_taxonomy_id,$stored_values)){
+                				$terms[] = $term;
+                    			}
+				}
+		 	}    	    
+		}
 
-		// return value
+		// return terms
 		return $terms;
 	}
 	

--- a/acf-tax.php
+++ b/acf-tax.php
@@ -320,13 +320,29 @@ class Tax_field extends acf_Field
 
 	function get_value($post_id, $field)
 	{
-		// get values
-		$terms = get_terms($field['taxonomy']);
-		$value = array();
+    		$value = array();
 
-		foreach($terms as $term) {
-			$val = intval( $term->term_id );
-			$value[] = $val;
+		if( is_numeric($post_id) )
+		{        
+    			// get values
+    			$terms = get_terms($field['taxonomy']);
+    
+    			foreach($terms as $term) {
+    				$val = intval( $term->term_id );
+    				$value[] = $val;
+    			}
+		}else{
+    			$stored_values = get_option( $post_id . '_' . $field['name'], null );
+    		
+            		if(is_array($stored_values)){
+    	 	    		$terms=wp_get_object_terms($post_id,$field['taxonomy']);
+            			foreach($terms as $term) {
+        				$val = intval( $term->term_id );
+                    			if(in_array($term->term_taxonomy_id,$stored_values)){
+                				$value[] = $val;
+                    			}
+				}
+		 	}    	    
 		}
 
 		// return value


### PR DESCRIPTION
I noticed that get_value() wasn't returning the right values when using this field type in a woocommerce attribute. I suppose this will always happen with taxonomies.

This is a quick fix...
